### PR TITLE
Move jest and supertest to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,7 @@
         "axios": "^0.19.0",
         "bn.js": "^5.0.0",
         "cookie": "^0.3.1",
-        "cookie-parser": "^1.4.3",
-        "jest": "^24.8.0",
-        "supertest": "^4.0.2"
+        "cookie-parser": "^1.4.3"
     },
     "devDependencies": {
         "@types/bn.js": "^4.11.5",
@@ -66,9 +64,11 @@
         "eslint-config-prettier": "^6.5.0",
         "eslint-plugin-prettier": "^3.1.0",
         "express": "^4.17.1",
+        "jest": "^24.8.0",
         "node-mocks-http": "^1.8.0",
         "prettier": "^1.19.1",
         "semantic-release": "^12.4.1",
+        "supertest": "^4.0.2",
         "ts-jest": "^24.1.0",
         "typescript": "^3.7.2"
     }


### PR DESCRIPTION
Npm audit is reporting issues related to these dependencies, by moving them to dev they won't be included in our audit anymore.